### PR TITLE
Add Cloud Native Playground to Resources section

### DIFF
--- a/malta.config.json
+++ b/malta.config.json
@@ -46,6 +46,12 @@
       ]
     },
     {
+      "title": "Cloud Native Tools",
+      "pages": [
+        ["Cloud Native Playground", "https://play.meshery.io"]
+      ]
+    },
+    {
       "title": "Links",
       "pages": [
         ["GitHub", "https://github.com/James-Kua/AwesomeDevOps"]


### PR DESCRIPTION
This PR adds the [Cloud Native Playground](https://play.meshery.io). 

The Cloud Native Playground is a free platform offering live Kubernetes clusters, enabling users to configure and deploy various CNCF projects. It's an excellent resource for learning and experimentation in the cloud-native ecosystem.

**Details**:
- **Resource Added**: Cloud Native Playground
- **Link**: [https://play.meshery.io](https://play.meshery.io)
- **Description**: A free resource offering live Kubernetes clusters to configure and deploy CNCF projects, enhancing learning and experimentation.
