### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,129 @@
+
+
+# Awesome DevOps
+
+This repository is a curated collection of tools, articles, and resources for anyone interested in DevOps—from beginners trying to understand the fundamentals to experienced engineers looking to improve their workflows.
+
+It brings together tools, frameworks, and reading materials spanning CI/CD, Infrastructure as Code (IaC), monitoring, security, and more. The goal is to offer a single place to explore and learn everything that fits under the broad umbrella of modern DevOps practices.
+
+---
+
+## Contents
+
+* [Overview](#overview)
+* [CI/CD Tools](#cicd-tools)
+* [Infrastructure as Code](#infrastructure-as-code)
+* [Monitoring & Logging](#monitoring--logging)
+* [Containers & Orchestration](#containers--orchestration)
+* [Security & Compliance](#security--compliance)
+* [Learning Resources](#learning-resources)
+* [Community & Conferences](#community--conferences)
+* [Contributing](#contributing)
+* [License](#license)
+
+---
+
+## Overview
+
+DevOps isn't a single tool or technology. It’s a cultural shift focused on improving collaboration between development and operations, enabling faster releases, better quality, and greater alignment with business goals.
+
+This repository aims to simplify the process of discovering valuable DevOps tools and practices by organizing them into accessible categories.
+
+---
+
+## CI/CD Tools
+
+Automate and streamline the software delivery process with these tools:
+
+* [Jenkins](https://www.jenkins.io/)
+* [GitHub Actions](https://github.com/features/actions)
+* [GitLab CI/CD](https://docs.gitlab.com/ee/ci/)
+* [CircleCI](https://circleci.com/)
+* [Travis CI](https://travis-ci.org/)
+
+---
+
+## Infrastructure as Code
+
+Define, provision, and manage infrastructure using code:
+
+* [Terraform](https://www.terraform.io/)
+* [Ansible](https://www.ansible.com/)
+* [Pulumi](https://www.pulumi.com/)
+* [Chef](https://www.chef.io/)
+* [SaltStack](https://saltproject.io/)
+
+---
+
+## Monitoring & Logging
+
+Track performance, detect failures, and ensure observability:
+
+* [Prometheus](https://prometheus.io/)
+* [Grafana](https://grafana.com/)
+* [ELK Stack (Elasticsearch, Logstash, Kibana)](https://www.elastic.co/elk-stack)
+* [Datadog](https://www.datadoghq.com/)
+* [New Relic](https://newrelic.com/)
+
+---
+
+## Containers & Orchestration
+
+Manage containerized applications efficiently:
+
+* [Docker](https://www.docker.com/)
+* [Kubernetes](https://kubernetes.io/)
+* [Helm](https://helm.sh/)
+* [OpenShift](https://www.openshift.com/)
+* [Rancher](https://rancher.com/)
+
+---
+
+## Security & Compliance
+
+Secure DevOps pipelines and ensure compliance:
+
+* [Snyk](https://snyk.io/)
+* [Aqua Security](https://www.aquasec.com/)
+* [Anchore](https://anchore.com/)
+* [Clair](https://github.com/quay/clair)
+* [Trivy](https://aquasecurity.github.io/trivy/)
+
+---
+
+## Learning Resources
+
+Recommended books and articles to deepen your understanding:
+
+* *The Phoenix Project* by Gene Kim, Kevin Behr, and George Spafford
+* *The DevOps Handbook* by Gene Kim, Jez Humble, Patrick Debois, and John Willis
+* *Site Reliability Engineering* by Google
+* *Continuous Delivery* by Jez Humble and David Farley
+* [DevOps Roadmap](https://roadmap.sh/devops)
+
+---
+
+## Community & Conferences
+
+Stay updated, learn from peers, and engage with the DevOps ecosystem:
+
+* [DevOps Days](https://devopsdays.org/)
+* [KubeCon + CloudNativeCon](https://www.cncf.io/kubecon-cloudnativecon-events/)
+* [HashiConf](https://www.hashiconf.com/)
+* [DockerCon](https://www.docker.com/dockercon/)
+* [SREcon](https://www.usenix.org/conference/srecon23americas)
+
+---
+
+## Contributing
+
+Contributions are welcome. If you have a resource that you think fits this collection, feel free to open a pull request. For larger changes or suggestions, please open an issue first to discuss your idea.
+
+---
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+---
+


### PR DESCRIPTION
Add Meshery, Playground, and Kanvas to awesome DevOps list

This PR adds Meshery, its Playground, and Kanvas extension to the list as per meshery/meshery#13426.